### PR TITLE
Fixed closing Navbar bug

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -10,7 +10,7 @@
   <link rel="shortcut icon" href="images/FSfront2.jpg"/>
   <link rel="stylesheet" type="text/css" href="stylesheet/bootstrap.min.css"/>
   <link rel="stylesheet" type="text/css" href="stylesheet/style.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.9/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
   <title><?=htmlspecialchars($title) ?></title>
   <script type="text/javascript">


### PR DESCRIPTION
This fixes issue #2. Looks like some error with the used jquery version >=2.
The PR downgrade the jquery version to 1.9.9 that is also supported by bootstrap 3. Don't see any jquery 3 related js code, so i think the downgrade is ok.